### PR TITLE
add payment requirements in offer response

### DIFF
--- a/offers.go
+++ b/offers.go
@@ -34,6 +34,13 @@ type (
 		Slices                             []Slice                 `json:"slices"`
 		Passengers                         []OfferRequestPassenger `json:"passengers"`
 		PassengerIdentityDocumentsRequired bool                    `json:"passenger_identity_documents_required"`
+		PaymentRequirements                OfferPaymentRequirement `json:"payment_requirements"`
+	}
+
+	OfferPaymentRequirement struct {
+		RequiresInstantPayment  bool      `json:"requires_instant_payment"`
+		PriceGuaranteeExpiresAt *DateTime `json:"price_guarantee_expires_at"`
+		PaymentRequiredBy       *DateTime `json:"payment_required_by"`
 	}
 
 	ListOffersSortParam string

--- a/offers_test.go
+++ b/offers_test.go
@@ -67,6 +67,9 @@ func TestGetOfferByID(t *testing.T) {
 	a.NotNil(data)
 	a.Equal("45.00 GBP", data.TotalAmount().String())
 	a.Len(data.Slices, 1)
+	a.False(data.PaymentRequirements.RequiresInstantPayment)
+	a.Equal(time.Date(2020, 1, 17, 10, 42, 14, 0, time.UTC).Unix(), time.Time(*data.PaymentRequirements.PriceGuaranteeExpiresAt).Unix())
+	a.Equal(time.Date(2020, 1, 17, 10, 42, 14, 0, time.UTC).Unix(), time.Time(*data.PaymentRequirements.PaymentRequiredBy).Unix())
 }
 
 func TestUpdateOffserPassenger(t *testing.T) {


### PR DESCRIPTION
Hello @ivanvanderbyl,

Thanks for open sourcing this library.
This PR add `payment_requirements` to the Offer struct. 

![image](https://user-images.githubusercontent.com/9210742/162481239-14760b82-8809-4bc1-97d9-5aae22f0f57d.png)

