### PR TITLE
Change ArrivingAt and DepartingAt to methods that use zone

### DIFF
--- a/duffel.go
+++ b/duffel.go
@@ -68,8 +68,8 @@ type (
 		Distance                     Distance           `json:"distance,omitempty"`
 		DestinationTerminal          string             `json:"destination_terminal"`
 		Destination                  Location           `json:"destination"`
-		DepartingAt                  DateTime           `json:"departing_at"`
-		ArrivingAt                   DateTime           `json:"arriving_at"`
+		RawDepartingAt               string             `json:"departing_at"`
+		RawArrivingAt                string             `json:"arriving_at"`
 		Aircraft                     Aircraft           `json:"aircraft"`
 	}
 

--- a/flight.go
+++ b/flight.go
@@ -1,0 +1,31 @@
+package duffel
+
+import "time"
+
+func (f *Flight) DepartingAt() (time.Time, error) {
+	loc, err := time.LoadLocation(f.Origin.TimeZone)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	t, err := time.ParseInLocation("2006-01-02T15:04:05", f.RawDepartingAt, loc)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return t, err
+}
+
+func (f *Flight) ArrivingAt() (time.Time, error) {
+	loc, err := time.LoadLocation(f.Destination.TimeZone)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	t, err := time.ParseInLocation("2006-01-02T15:04:05", f.RawArrivingAt, loc)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return t, err
+}

--- a/offerrequests_test.go
+++ b/offerrequests_test.go
@@ -88,6 +88,16 @@ func TestGetOfferRequest(t *testing.T) {
 	a.Equal("airport", data.Offers[0].Slices[0].DestinationType)
 	a.Equal(false, data.Offers[0].Slices[0].Changeable)
 	a.Equal("Refundable Main Cabin", data.Offers[0].Slices[0].FareBrandName)
+
+	// Assert that departing at is in the correct timezone
+	dep, err := data.Offers[0].Slices[0].Segments[0].DepartingAt()
+	a.NoError(err)
+	est, _ := time.LoadLocation("America/New_York")
+	a.True(dep.Equal(time.Date(2021, time.December, 30, 8, 55, 0, 0, est)), "Departure time should be in EST")
+
+	arr, err := data.Offers[0].Slices[0].Segments[0].ArrivingAt()
+	a.NoError(err)
+	a.True(arr.Equal(time.Date(2021, time.December, 30, 12, 07, 0, 0, est)), "Arrival time should be in EST")
 }
 
 func TestListOfferRequests(t *testing.T) {


### PR DESCRIPTION
Changes the Segment#arrivingAt and Segment#departingAt to methods that use the correct zone of the origin and destination airport. This fixes a major bug where all times were incorrectly assumed to be UTC.