### PR TITLE
feat(flights): add FlightStop structure

### DIFF
--- a/duffel.go
+++ b/duffel.go
@@ -66,6 +66,7 @@ type (
 		OperatingCarrier             Airline            `json:"operating_carrier"`
 		MarketingCarrierFlightNumber string             `json:"marketing_carrier_flight_number"`
 		MarketingCarrier             Airline            `json:"marketing_carrier"`
+		Stops                        []FlightStop       `json:"stops,omitempty"`
 		Duration                     Duration           `json:"duration"`
 		Distance                     Distance           `json:"distance,omitempty"`
 		DestinationTerminal          string             `json:"destination_terminal"`
@@ -73,6 +74,13 @@ type (
 		RawDepartingAt               string             `json:"departing_at"`
 		RawArrivingAt                string             `json:"arriving_at"`
 		Aircraft                     Aircraft           `json:"aircraft"`
+	}
+
+	FlightStop struct {
+		ID             string   `json:"id"`
+		Duration       Duration `json:"duration"`
+		RawDepartingAt string   `json:"departing_at"`
+		Airport        Airport  `json:"airport"`
 	}
 
 	SegmentPassenger struct {


### PR DESCRIPTION
This PR adds `stops` list which describes additional segment-specific information about the stops, if any, included in the segment.

The structure of "stops":
```json
  "stops": [
    {
      "id": "sto_00009htYpSCXrwaB9Dn456",
      "duration": "PT02H26M",
      "departing_at": "2020-06-13T16:38:02",
      "airport": {
        "type": "airport",
        "time_zone": "Europe/London",
        "name": "Heathrow",
        "longitude": -141.951519,
        "latitude": 64.068865,
        "id": "arp_lhr_gb",
        "icao_code": "EGLL",
        "iata_country_code": "GB",
        "iata_code": "LHR",
        "iata_city_code": "LON",
        "city_name": "London",
        "city": {
          "name": "London",
          "id": "cit_lon_gb",
          "iata_country_code": "GB",
          "iata_code": "LON"
        },
        "airports": [
          {
            "time_zone": "Europe/London",
            "name": "Heathrow",
            "longitude": -141.951519,
            "latitude": 64.068865,
            "id": "arp_lhr_gb",
            "icao_code": "EGLL",
            "iata_country_code": "GB",
            "iata_code": "LHR",
            "iata_city_code": "LON",
            "city_name": "London",
            "city": {
              "name": "London",
              "id": "cit_lon_gb",
              "iata_country_code": "GB",
              "iata_code": "LON"
            }
          }
        ]
      }
    }
  ]
 ```